### PR TITLE
Splitted reset / victory log messages

### DIFF
--- a/ai/strategies.lua
+++ b/ai/strategies.lua
@@ -66,7 +66,14 @@ function Strategies.hardReset(reason, message, extra, wait)
 	local seed = Data.run.seed
 	local newmessage = message.." | "..seed
 
-	local f,  err = io.open(RUNS_FILE, "a")
+	local f, err
+
+	if reason~="won" then
+		f, err = io.open(RESET_LOG_FILE, "a")
+	else
+		f, err = io.open(VICTORY_LOG_FILE, "a")
+	end
+
 	if f==nil then
 		print("Couldn't open file: "..err)
 	else

--- a/main.lua
+++ b/main.lua
@@ -6,7 +6,8 @@ BEAST_MODE = false -- WARNING: Do not engage. Will yolo everything, and reset at
 INITIAL_SPEED = 750
 AFTER_BROCK_SPEED = 350
 
-RUNS_FILE = "C:/Users/rjrhy/Desktop/Pokebot/Github work/PokeBotBad/wiki/red/runs.txt" -- Use / insted of \ otherwise it will not work
+RESET_LOG_FILE = "C:/Users/rjrhy/Desktop/Pokebot/Github work/PokeBotBad/wiki/red/resets.txt" -- Use / insted of \ otherwise it will not work
+VICTORY_LOG_FILE = "C:/Users/rjrhy/Desktop/Pokebot/Github work/PokeBotBad/wiki/red/victories.txt"
 
 local CUSTOM_SEED  = nil -- Set to a known seed to replay it, or leave nil for random runs
 local NIDORAN_NAME = "A" -- Set this to the single character to name Nidoran (note, to replay a seed, it MUST match!)


### PR DESCRIPTION
I think this would be a nice addition since isolating finished runs isn't easy currently.

(Apparently "splitted" isn't correct, whoops)
