### PR TITLE
Added speed change option after Mt. Moon

### DIFF
--- a/ai/strategies.lua
+++ b/ai/strategies.lua
@@ -1078,8 +1078,11 @@ Strategies.functions = {
 	end,
 
 	speedchange = function(data)
-		p(data.extra..", speed changed to "..data.speed.."%")
-		client.speedmode(data.speed)
+		if data.speed~=CURRENT_SPEED then
+			p(data.extra..", speed changed to "..data.speed.."%")
+			client.speedmode(data.speed)
+			CURRENT_SPEED = data.speed
+		end
 		return true
 	end,
 

--- a/data/red/paths.lua
+++ b/data/red/paths.lua
@@ -57,7 +57,7 @@ local Paths = {
 	-- Pewter City
 	{2, {18,35}, {18,22}, {19,22}, {19,13}, {10,13}, {10,18}, {16,18}, {16,17}},
 	-- Brock
-	{54, {4,13}, {c="a",a="Brock's Gym"}, {4,8}, {1,8}, {1,4}, {4,4}, {4,2}, {s="talk",dir="Up"}, {s="fightBrock"}, {s="splitBrock"},{s="speedchange", speed=AFTER_BROCK_SPEED, extra="We have a run going"}, {4,14}},
+	{54, {4,13}, {c="a",a="Brock's Gym"}, {4,8}, {1,8}, {1,4}, {4,4}, {4,2}, {s="talk",dir="Up"}, {s="fightBrock"}, {s="splitBrock"}, {s="speedchange", speed=AFTER_BROCK_SPEED, extra="We have a run going"}, {4,14}},
 
 -- 3: BROCK
 
@@ -90,7 +90,7 @@ local Paths = {
 -- 5: MT. MOON
 
 	-- To Cerulean
-	{15, {24,6}, {s="reportMtMoon"}, {s="split"}, {c="trackEncounters",area=nil}, {24,8}, {35,8}, {35,10}, {61,10}, {61,8}, {79,8}, {79,10}, {90,10}},
+	{15, {24,6}, {s="reportMtMoon"}, {s="split"}, {s="speedchange", speed=AFTER_MOON_SPEED, extra="Things are getting serious"}, {c="trackEncounters",area=nil}, {24,8}, {35,8}, {35,10}, {61,10}, {61,8}, {79,8}, {79,10}, {90,10}},
 	-- Enter Cerulean
 	{3, {0,18}, {c="a",a="Cerulean"}, {14,18}, {s="dodgeCerulean"}, {19,18}, {19,17}},
 	-- Cerulean Center

--- a/main.lua
+++ b/main.lua
@@ -4,7 +4,8 @@ RESET_FOR_TIME = false -- Set to true if you're trying to break the record, not 
 BEAST_MODE = false -- WARNING: Do not engage. Will yolo everything, and reset at every opportunity in the quest for 1:47.
 
 INITIAL_SPEED = 750
-AFTER_BROCK_SPEED = 350
+AFTER_BROCK_SPEED = 550
+AFTER_MOON_SPEED = 350
 
 RUNS_FILE = "C:/Users/rjrhy/Desktop/Pokebot/Github work/PokeBotBad/wiki/red/runs.txt" -- Use / insted of \ otherwise it will not work
 
@@ -15,6 +16,7 @@ local PAINT_ON     = true -- Display contextual information while the bot runs
 -- START CODE (hard hats on)
 
 VERSION = "2.4.8"
+CURRENT_SPEED = nil
 
 local Data = require "data.data"
 
@@ -54,6 +56,7 @@ function resetAll()
 	Utils.reset()
 	oldSeconds = 0
 	running = false
+	CURRENT_SPEED = INITIAL_SPEED
 	client.speedmode(INITIAL_SPEED)
 
 	if CUSTOM_SEED then


### PR DESCRIPTION
Mt. Moon is a big run killer, it's just not fun to see a reset just because it took too much time, which I guess was the reason why a speed chance was added after Brock.

Also it doesn't output anything if previous speed is the same as the new one.
