### PR TITLE
Fixed wrong finish time in log file

### DIFF
--- a/ai/strategies.lua
+++ b/ai/strategies.lua
@@ -2256,10 +2256,8 @@ Strategies.functions = {
 					end
 				end
 				Bridge.guessResults("elite4", "victory")
-			elseif status.frames == 500 then
-				Bridge.chat("beat the game in "..status.finishTime.."!")
 			elseif status.frames > 1800 then
-				return Strategies.hardReset("won", "Finished the game in "..Utils.elapsedTime()..", Dont forget to follow the stream!")
+				return Strategies.hardReset("won", "Finished the game in "..status.finishTime)
 			end
 			status.frames = status.frames + 1
 		elseif Memory.value("menu", "shop_current") == 252 then


### PR DESCRIPTION
The log file recorded the time with a 30 seconds delay.

This also removes the similar message in the output window ("beat the game in...") since it pretty much said the same thing.
